### PR TITLE
SDK-700 : Add availability field to Managed Product API response

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 #### Changes
 - Update Host API version to v2.16
 - Support DA OAuth2 Login with PKCE Authorization Code Flow
+- Add availability field to Managed Product API response
 
 ### 3.11.1
 

--- a/src/androidTest/kotlin/us/frollo/frollosdk/managedproducts/ManagedProductsTest.kt
+++ b/src/androidTest/kotlin/us/frollo/frollosdk/managedproducts/ManagedProductsTest.kt
@@ -33,6 +33,7 @@ import us.frollo.frollosdk.base.Result
 import us.frollo.frollosdk.error.DataError
 import us.frollo.frollosdk.error.DataErrorSubType
 import us.frollo.frollosdk.error.DataErrorType
+import us.frollo.frollosdk.model.coredata.managedproduct.ManagedProductAvailability
 import us.frollo.frollosdk.network.api.ManagedProductsAPI
 import us.frollo.frollosdk.test.R
 import us.frollo.frollosdk.testutils.readStringFromJson
@@ -168,6 +169,11 @@ class ManagedProductsTest : BaseAndroidTest() {
             assertEquals(2L, model?.features?.last()?.featureId)
             assertEquals("Set your goals", model?.features?.last()?.description)
             assertNull(model?.features?.last()?.additionalInfo)
+            assertEquals(2, model?.availability?.size)
+            assertEquals(ManagedProductAvailability.ONBOARDING_REQUIRED, model?.availability?.first())
+            assertEquals(ManagedProductAvailability.POST_ONBOARDING, model?.availability?.last())
+
+            assertEquals(ManagedProductAvailability.ONBOARDING_OPTIONAL, models?.last()?.availability?.first())
 
             signal.countDown()
         }

--- a/src/androidTest/res/raw/managed_products_response.json
+++ b/src/androidTest/res/raw/managed_products_response.json
@@ -27,6 +27,9 @@
 					"description": "Set your goals",
 					"created_at": "2021-09-30T10:36:58.682+10:00"
 				}
+			],
+			"availability": [
+				"onboarding_required", "post_onboarding"
 			]
 		},
 		{
@@ -55,6 +58,9 @@
 					"name": "Volt Bank Cash Terms & Conditions",
 					"url": "https://www.voltbank.com.au/voltsaveterms"
 				}
+			],
+			"availability": [
+				"onboarding_optional"
 			]
 		}
 	],

--- a/src/main/kotlin/us/frollo/frollosdk/model/coredata/managedproduct/ManagedProduct.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/model/coredata/managedproduct/ManagedProduct.kt
@@ -40,5 +40,8 @@ data class ManagedProduct(
     @SerializedName("terms_conditions") val termsConditions: List<TermsCondition>,
 
     /** List of [ProductFeature] of the [ManagedProduct] (Optional) */
-    @SerializedName("features") val features: List<ProductFeature>?
+    @SerializedName("features") val features: List<ProductFeature>?,
+
+    /** Indicates which app flow, this product is applicable for creation (Optional)*/
+    @SerializedName("availability") val availability: List<ManagedProductAvailability>?
 )

--- a/src/main/kotlin/us/frollo/frollosdk/model/coredata/managedproduct/ManagedProductAvailability.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/model/coredata/managedproduct/ManagedProductAvailability.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Frollo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package us.frollo.frollosdk.model.coredata.managedproduct
+
+import com.google.gson.annotations.SerializedName
+import us.frollo.frollosdk.extensions.serializedName
+
+/** Availability of the Product */
+enum class ManagedProductAvailability {
+
+    /** Product is mandatory to be created during Onboarding */
+    @SerializedName("onboarding_required") ONBOARDING_REQUIRED,
+
+    /** Product is optional to be created during Onboarding */
+    @SerializedName("onboarding_optional") ONBOARDING_OPTIONAL,
+
+    /** Product can be created post Onboarding */
+    @SerializedName("post_onboarding") POST_ONBOARDING;
+
+    /** Enum to serialized string */
+    // This override MUST be used for this enum to work with Retrofit @Path or @Query parameters
+    override fun toString(): String =
+        // Try to get the annotation value if available instead of using plain .toString()
+        // Fallback to super.toString() in case annotation is not present/available
+        serializedName() ?: super.toString()
+}


### PR DESCRIPTION
## The problem ##

[SDK-700](https://frollo.atlassian.net/browse/SDK-700)
[API Docs](https://frollo.stoplight.io/docs/frollo-api/branches/version%2F2.15/b3A6MjQwOTI2NDY-list-available-products)

## Checklist ##

* Is the destination branch correct & intended?:white_check_mark:
* Is the code synced to latest (if applicable)?:white_check_mark:
* Has the SDK example app build passed locally?:white_check_mark:
* Is the correct JIRA ticket referenced?:white_check_mark:
* Is the correct API docs/Confluence Page referenced?:white_check_mark:
* Have all the AC's in the ticket passed?:white_check_mark:
* Have you followed proper naming conventions in the code?:white_check_mark:
* Has the code been properly covered with unit & android tests?:white_check_mark:
* Have the full test suite (unit & android tests) passed locally?:white_check_mark:
* Has the changelog.md, packages.md, overview.md, extras.md been updated?:white_check_mark:
* Has the dokka task passed?:white_check_mark:
* Have you committed database schema changes (if applicable)?:white_check_mark:

## Results ##

![Screen Shot 2021-12-02 at 10 01 45 am](https://user-images.githubusercontent.com/47196284/144331863-4225e712-0d04-46a9-b19e-f1014aab34aa.png)