### PR TITLE
WA-4430: SDK - Delete Manual transaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ android {
         versionName "3.22.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // Clear existing data for package using 'pm clear'
+        testInstrumentationRunnerArguments clearPackageData: 'true'
         manifestPlaceholders = ['appAuthRedirectScheme': 'frollo-sdk-test']
         buildConfigField "String", "SDK_VERSION_NAME", "\"$versionName\""
         buildConfigField "int", "SDK_VERSION_CODE", "$versionCode"

--- a/src/main/kotlin/us/frollo/frollosdk/aggregation/Aggregation.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/aggregation/Aggregation.kt
@@ -1494,6 +1494,30 @@ class Aggregation(network: NetworkService, internal val db: SDKDatabase, localBr
     }
 
     /**
+     * Delete a manual transaction
+     *
+     * @param transactionId Transaction to delete
+     * @param completion Optional completion handler with optional error if the request fails or succeeds
+     */
+    fun deleteManualTransaction(
+        transactionId: Long,
+        completion: OnFrolloSDKCompletionListener<Result>?
+    ) {
+        aggregationAPI.deleteManualTransaction(transactionId).enqueue { resource ->
+            when (resource.status) {
+                Resource.Status.SUCCESS -> {
+                    removeCachedTransactions(longArrayOf(transactionId))
+                    completion?.invoke(Result.success())
+                }
+                Resource.Status.ERROR -> {
+                    Log.e("$TAG#deleteManualTransaction", resource.error?.localizedDescription)
+                    completion?.invoke(Result.error(resource.error))
+                }
+            }
+        }
+    }
+
+    /**
      * Fetch transactions summary from a certain period from the host
      *
      * @param fromDate Start date to fetch transactions summary from (inclusive). Please use [TransactionsSummary.DATE_FORMAT_PATTERN] for the format pattern.

--- a/src/main/kotlin/us/frollo/frollosdk/database/SDKDatabase.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/database/SDKDatabase.kt
@@ -117,7 +117,7 @@ import us.frollo.frollosdk.model.coredata.user.User
         ExternalParty::class,
         DisclosureConsent::class
     ],
-    version = 21, exportSchema = true
+    version = 22, exportSchema = true
 )
 
 @TypeConverters(Converters::class)

--- a/src/main/kotlin/us/frollo/frollosdk/network/api/AggregationAPI.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/network/api/AggregationAPI.kt
@@ -152,6 +152,9 @@ internal interface AggregationAPI {
     @POST(URL_TRANSACTIONS)
     fun createManualTransaction(@Body request: ManualTransactionCreateUpdateRequest): Call<TransactionResponse>
 
+    @DELETE(URL_TRANSACTION)
+    fun deleteManualTransaction(@Path("transaction_id") transactionId: Long): Call<Void>
+
     @PUT(URL_TRANSACTIONS_BULK)
     fun updateTransactionsInBulk(@Body request: List<TransactionBulkUpdateRequest>): Call<List<TransactionResponse>>
 


### PR DESCRIPTION
## The problem ##

As per JIRA:
WA-4430

* Created manual transaction deletion endpoint
* Created manual transaction deletion service API
* Added 2 relevant unit tests, one fore success, one for failure case
* For testing, ensure package is cleared of any existing data (pm clear) in Gradle configuration
* Bump SDK DB Version from 21 -> 22
No architecture changes
