### PR TITLE
WA-4437: Add Last business day of the month to Payday

### DIFF
--- a/src/main/kotlin/us/frollo/frollosdk/model/coredata/payday/PaydayFrequency.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/model/coredata/payday/PaydayFrequency.kt
@@ -39,6 +39,11 @@ enum class PaydayFrequency {
     /** Weekly */
     @SerializedName("weekly") WEEKLY,
 
+    /**
+     * Last business day of month
+     */
+    @SerializedName("monthly_last_businessday") MONTHLY_LAST_BUSINESS_DAY,
+
     /** Unknown */
     @SerializedName("unknown") UNKNOWN;
 

--- a/src/main/kotlin/us/frollo/frollosdk/paydays/Paydays.kt
+++ b/src/main/kotlin/us/frollo/frollosdk/paydays/Paydays.kt
@@ -84,7 +84,14 @@ class Paydays(network: NetworkService, internal val db: SDKDatabase) {
         nextDate: String? = null,
         completion: OnFrolloSDKCompletionListener<Result>? = null
     ) {
-        val request = PaydayUpdateRequest(frequency = frequency, nextDate = nextDate)
+        val request: PaydayUpdateRequest =
+            if (frequency == PaydayFrequency.MONTHLY_LAST_BUSINESS_DAY || frequency == PaydayFrequency.IRREGULAR) {
+                // These cases don't supply a nextDate
+                PaydayUpdateRequest(frequency = frequency)
+            } else {
+                // Every other case supplies a nextDate
+                PaydayUpdateRequest(frequency = frequency, nextDate = nextDate)
+            }
 
         paydayAPI.updatePayday(request).enqueue { resource ->
             when (resource.status) {


### PR DESCRIPTION
## The problem ##

As per ticket WA-4437:
* Update PaydayFrequency to have MONTHLY_LAST_BUSINESS_DAY
* Update API to handle new enum type PaydayFrequency.MONTHLY_LAST_BUSINESS_DAY
